### PR TITLE
feat: collapse proposal description

### DIFF
--- a/src/xgov-dapp/src/shared/ProposalCard.tsx
+++ b/src/xgov-dapp/src/shared/ProposalCard.tsx
@@ -1,6 +1,8 @@
+import {useRef, useState} from 'react'
 import LaunchIcon from '@mui/icons-material/Launch'
-import { Chip, LinearProgress, Link, Paper, Typography } from '@mui/material'
+import {Chip, Collapse, LinearProgress, Link, Paper, Typography, useTheme} from '@mui/material'
 import { AbstainChip, CategoryChip, DidNotPassChip, MockProposalChip, PassedChip, VotesNeededToPassChip } from './Chips'
+import {useOverflow} from "./hooks/useOverflow";
 
 type ProposalCardProps = {
   link: string | undefined
@@ -25,6 +27,11 @@ export const ProposalCard = ({
   votesTally = 0,
   hasClosed = false,
 }: ProposalCardProps) => {
+  // Handle collapse state
+  const descriptionRef = useRef(null);
+  const isOverflow = useOverflow(descriptionRef)
+  const [expanded,setExpanded] = useState(false);
+  // Derived State
   const percentage = threshold && threshold > 0 ? Math.min(100, (votesTally / threshold) * 100) : 100
   const hasPassed = percentage >= 100
   const votesNeeded = threshold && threshold > 0 ? threshold - votesTally : 0
@@ -53,7 +60,16 @@ export const ProposalCard = ({
           </Typography>
         </div>
         <LinearProgress color="error" style={{ height: 8, borderRadius: 10 }} className="mb-4" variant="determinate" value={100} />
-        {description && <Typography>{description}</Typography>}
+        {description &&
+          <Collapse
+          ref={descriptionRef}
+          collapsedSize={`${1.5 * 4}rem`}
+          in={expanded}
+        >
+          <Typography>{description}</Typography>
+        </Collapse>
+        }
+        {isOverflow && <Typography className="text-right mt-2 cursor-pointer" onClick={() => setExpanded(!expanded)}>{expanded ? "Show Less": "Read More"}</Typography>}
       </Paper>
     )
   }
@@ -94,7 +110,16 @@ export const ProposalCard = ({
         </Typography>
       </div>
       <LinearProgress color="success" style={{ height: 8, borderRadius: 10 }} className="mb-4" variant="determinate" value={percentage} />
-      {description && <Typography>{description}</Typography>}
+      {description &&
+        <Collapse
+          ref={descriptionRef}
+          collapsedSize={`${1.5 * 4}rem`}
+          in={expanded}
+        >
+          <Typography>{description}</Typography>
+        </Collapse>
+      }
+      {isOverflow && <Typography className="text-right mt-2 cursor-pointer" onClick={() => setExpanded(!expanded)}>{expanded ? "Show Less": "Read More"}</Typography>}
     </Paper>
   )
 }

--- a/src/xgov-dapp/src/shared/hooks/useOverflow.ts
+++ b/src/xgov-dapp/src/shared/hooks/useOverflow.ts
@@ -1,0 +1,25 @@
+import React, {useLayoutEffect} from "react";
+import type {MutableRefObject} from "react";
+
+export const useOverflow = (ref: MutableRefObject<HTMLElement|null>, callback?: (hasOverflow: boolean)=> boolean) => {
+  const [isOverflow, setIsOverflow] = React.useState<boolean | undefined>(undefined);
+
+  useLayoutEffect(() => {
+    const { current } = ref;
+
+    const trigger = () => {
+      if (!current) return;
+      const hasOverflow = current.scrollHeight > current.clientHeight;
+
+      setIsOverflow(hasOverflow);
+
+      if (callback) callback(hasOverflow);
+    };
+
+    if (current) {
+      trigger();
+    }
+  }, [callback, ref]);
+
+  return isOverflow;
+};


### PR DESCRIPTION
# Overview

- Adds `useOverflow` hook
- Uses MUI `Collapse` for proposal description
- Displays "Read More" "Show Less" if content is overflowing

## Blockers

- #96 

Related Issues

- https://algorandfoundation.atlassian.net/browse/AF-69