### PR TITLE
fix: disable shuffle on tally changes

### DIFF
--- a/src/xgov-dapp/src/features/vote/VoteDetails.tsx
+++ b/src/xgov-dapp/src/features/vote/VoteDetails.tsx
@@ -9,7 +9,7 @@ export type VoteDetailsProps = {
   globalState: VotingRoundGlobalState | undefined
   roundMetadata: VotingRoundMetadata | undefined
 }
-export const VoteDetails = ({ loading, appId: voteId, globalState, roundMetadata }: VoteDetailsProps) => {
+export const VoteDetails = ({ loading: _loading, appId: voteId, globalState, roundMetadata }: VoteDetailsProps) => {
   return (
     <>
       {globalState && roundMetadata && (

--- a/src/xgov-dapp/src/features/vote/index.tsx
+++ b/src/xgov-dapp/src/features/vote/index.tsx
@@ -3,7 +3,7 @@ import { useWallet } from '@makerx/use-wallet'
 import CancelIcon from '@mui/icons-material/Cancel'
 import { Alert, Box, Button, IconButton, InputAdornment, Link, Skeleton, TextField, Typography } from '@mui/material'
 import clsx from 'clsx'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link as RouterLink, useNavigate, useParams } from 'react-router-dom'
 import {
   VoteGatingSnapshot,
@@ -378,6 +378,14 @@ function Vote({ sort: sortProp = 'none' }: { sort?: 'ascending' | 'descending' |
     )
   }
 
+  // Randomize questions on metadata change
+  const randomQuestions = useMemo<Question[]>(() => {
+    if (votingRoundMetadata && Array.isArray(votingRoundMetadata.questions) && votingRoundMetadata.questions.length > 0) {
+      return votingRoundMetadata.questions.shuffle()
+    } else {
+      return []
+    }
+  }, [votingRoundMetadata])
   return (
     <div>
       <div className="mb-4">
@@ -440,13 +448,12 @@ function Vote({ sort: sortProp = 'none' }: { sort?: 'ascending' | 'descending' |
                 <Skeleton className="h-40" variant="rectangular" />
               </div>
             )}
-            {votingRoundMetadata?.questions
-              .shuffle()
+            {randomQuestions
               .filter(filterQuestions)
               .sort(sortQuestions)
               .sort(pinPassedQuestions)
               .map((question, index) => (
-                <div key={index} className="col-span-3 grid grid-cols-1 lg:grid-cols-3 gap-4 bg-white rounded-lg">
+                <div key={question.id} className="col-span-3 grid grid-cols-1 lg:grid-cols-3 gap-4 bg-white rounded-lg">
                   <div className="col-span-2">
                     {question.metadata && (
                       <ProposalCard

--- a/src/xgov-dapp/src/features/vote/index.tsx
+++ b/src/xgov-dapp/src/features/vote/index.tsx
@@ -64,7 +64,6 @@ function Vote({ sort: sortProp = 'none' }: { sort?: 'ascending' | 'descending' |
   const [voterVotes, setVoterVotes] = useState<string[] | undefined>(undefined)
 
   const [isLoadingVotingRoundData, setIsLoadingVotingRoundData] = useState(true)
-  const [_isLoadingVotersVote, setIsLoadingVotersVote] = useState(true)
   const [isLoadingVotingRoundResults, setIsLoadingVotingRoundResults] = useState(true)
 
   const [error, setError] = useState<string | null>(null)
@@ -192,16 +191,12 @@ function Vote({ sort: sortProp = 'none' }: { sort?: 'ascending' | 'descending' |
     votingRoundGlobalState: VotingRoundGlobalState | undefined,
   ) => {
     if (voteId && walletAddress && votingRoundMetadata && votingRoundGlobalState) {
-      setIsLoadingVotersVote(true)
       try {
         setVoterVotes(await fetchVoterVotes(voteId, walletAddress, votingRoundMetadata, votingRoundGlobalState))
-        setIsLoadingVotersVote(false)
       } catch (e) {
-        setIsLoadingVotersVote(false)
         handleError(e)
       }
     } else {
-      setIsLoadingVotersVote(false)
       setVoterVotes(undefined)
     }
   }

--- a/src/xgov-dapp/src/features/vote/index.tsx
+++ b/src/xgov-dapp/src/features/vote/index.tsx
@@ -64,9 +64,8 @@ function Vote({ sort: sortProp = 'none' }: { sort?: 'ascending' | 'descending' |
   const [voterVotes, setVoterVotes] = useState<string[] | undefined>(undefined)
 
   const [isLoadingVotingRoundData, setIsLoadingVotingRoundData] = useState(true)
-  const [isLoadingVotersVote, setIsLoadingVotersVote] = useState(true)
+  const [_isLoadingVotersVote, setIsLoadingVotersVote] = useState(true)
   const [isLoadingVotingRoundResults, setIsLoadingVotingRoundResults] = useState(true)
-  const isLoadingResults = isLoadingVotersVote || isLoadingVotingRoundResults
 
   const [error, setError] = useState<string | null>(null)
 
@@ -80,7 +79,6 @@ function Vote({ sort: sortProp = 'none' }: { sort?: 'ascending' | 'descending' |
   const { loading: closingVotingRound, execute: closeVotingRound, error: closingVotingRoundError } = api.useCloseVotingRound()
 
   const totalAllocatedPercentage = Object.values(voteAllocationsPercentage).reduce((a, b) => a + b, 0)
-  const totalAllocated = Object.values(voteAllocations).reduce((a, b) => a + b, 0)
 
   const hasVoteStarted = !votingRoundGlobalState ? false : getHasVoteStarted(votingRoundGlobalState)
   const hasVoteEnded = !votingRoundGlobalState ? false : getHasVoteEnded(votingRoundGlobalState)
@@ -452,7 +450,7 @@ function Vote({ sort: sortProp = 'none' }: { sort?: 'ascending' | 'descending' |
               .filter(filterQuestions)
               .sort(sortQuestions)
               .sort(pinPassedQuestions)
-              .map((question, index) => (
+              .map((question) => (
                 <div key={question.id} className="col-span-3 grid grid-cols-1 lg:grid-cols-3 gap-4 bg-white rounded-lg">
                   <div className="col-span-2">
                     {question.metadata && (

--- a/src/xgov-dapp/src/features/wallet/manualSigningProvider.ts
+++ b/src/xgov-dapp/src/features/wallet/manualSigningProvider.ts
@@ -19,7 +19,7 @@ const manualWalletAtom = atom<ManualWallet>({
 const showManualWalletModalSelector = selector({
   key: 'showManualWalletModalSelector',
   get: ({ get }) => get(manualWalletAtom).showManualWalletModal,
-  set: ({ set, get }, newValue) => {
+  set: ({ set, get: _get }, newValue) => {
     set(manualWalletAtom, {
       showManualWalletModal: newValue instanceof DefaultValue ? false : newValue,
       payloadToSign: '',

--- a/src/xgov-dapp/src/shared/ProposalCard.tsx
+++ b/src/xgov-dapp/src/shared/ProposalCard.tsx
@@ -28,13 +28,21 @@ export const ProposalCard = ({
   hasClosed = false,
 }: ProposalCardProps) => {
   // Handle collapse state
-  const descriptionRef = useRef(null)
-  const isOverflow = useOverflow(descriptionRef)
+  const [isOverflow, setIsOverflow] = useState(false)
+  const { ref } = useOverflow((result) => {
+    if (result !== isOverflow) setIsOverflow(result)
+  })
+  const [hasOpened, setHasOpened] = useState(false)
   const [expanded, setExpanded] = useState(false)
   // Derived State
   const percentage = threshold && threshold > 0 ? Math.min(100, (votesTally / threshold) * 100) : 100
   const hasPassed = percentage >= 100
   const votesNeeded = threshold && threshold > 0 ? threshold - votesTally : 0
+
+  function handleClick(){
+    if(!hasOpened) setHasOpened(true)
+    setExpanded(!expanded)
+  }
 
   if (category === 'Abstain') {
     return (
@@ -61,12 +69,12 @@ export const ProposalCard = ({
         </div>
         <LinearProgress color="error" style={{ height: 8, borderRadius: 10 }} className="mb-4" variant="determinate" value={100} />
         {description && (
-          <Collapse ref={descriptionRef} collapsedSize={`${1.5 * 4}rem`} in={expanded}>
+          <Collapse ref={ref} collapsedSize={`${1.5 * 4}rem`} in={expanded}>
             <Typography>{description}</Typography>
           </Collapse>
         )}
-        {isOverflow && (
-          <Typography className="text-right mt-2 cursor-pointer" onClick={() => setExpanded(!expanded)}>
+        {(isOverflow || hasOpened) && (
+          <Typography className="text-right mt-2 cursor-pointer" onClick={handleClick}>
             {expanded ? 'Show Less' : 'Read More'}
           </Typography>
         )}
@@ -111,12 +119,12 @@ export const ProposalCard = ({
       </div>
       <LinearProgress color="success" style={{ height: 8, borderRadius: 10 }} className="mb-4" variant="determinate" value={percentage} />
       {description && (
-        <Collapse ref={descriptionRef} collapsedSize={`${1.5 * 4}rem`} in={expanded}>
+        <Collapse ref={ref} collapsedSize={`${1.5 * 4}rem`} in={expanded}>
           <Typography>{description}</Typography>
         </Collapse>
       )}
-      {isOverflow && (
-        <Typography className="text-right mt-2 cursor-pointer" onClick={() => setExpanded(!expanded)}>
+      {(isOverflow || hasOpened) && (
+        <Typography className="text-right mt-2 cursor-pointer" onClick={handleClick}>
           {expanded ? 'Show Less' : 'Read More'}
         </Typography>
       )}

--- a/src/xgov-dapp/src/shared/ProposalCard.tsx
+++ b/src/xgov-dapp/src/shared/ProposalCard.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import LaunchIcon from '@mui/icons-material/Launch'
 import { Chip, Collapse, LinearProgress, Link, Paper, Typography } from '@mui/material'
 import { AbstainChip, CategoryChip, DidNotPassChip, MockProposalChip, PassedChip, VotesNeededToPassChip } from './Chips'
@@ -39,8 +39,8 @@ export const ProposalCard = ({
   const hasPassed = percentage >= 100
   const votesNeeded = threshold && threshold > 0 ? threshold - votesTally : 0
 
-  function handleClick(){
-    if(!hasOpened) setHasOpened(true)
+  function handleClick() {
+    if (!hasOpened) setHasOpened(true)
     setExpanded(!expanded)
   }
 

--- a/src/xgov-dapp/src/shared/hooks/useOverflow.ts
+++ b/src/xgov-dapp/src/shared/hooks/useOverflow.ts
@@ -1,25 +1,19 @@
-import React, { useLayoutEffect } from 'react'
-import type { MutableRefObject } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
 
-export const useOverflow = (ref: MutableRefObject<HTMLElement | null>, callback?: (hasOverflow: boolean) => boolean) => {
-  const [isOverflow, setIsOverflow] = React.useState<boolean | undefined>(undefined)
-
+export const useOverflow = (onChange?: (isOverflow: boolean) => void) => {
+  const [isOverflow, setIsOverflow] = useState<boolean>()
+  const ref = useRef<HTMLElement>()
   useLayoutEffect(() => {
     const { current } = ref
-
-    const trigger = () => {
-      if (!current) return
-      const hasOverflow = current.scrollHeight > current.clientHeight
-
-      setIsOverflow(hasOverflow)
-
-      if (callback) callback(hasOverflow)
+    if (!current) {
+      return
     }
+    const hasOverflow = current.scrollHeight > current.clientHeight
 
-    if (current) {
-      trigger()
-    }
-  }, [callback, ref])
+    setIsOverflow(hasOverflow)
 
-  return isOverflow
+    if (onChange) onChange(hasOverflow)
+  }, [onChange, ref])
+
+  return { ref, isOverflow }
 }


### PR DESCRIPTION
# Overview

- disable shuffle on specific state changes
- simplify useOverflow hook for reflectivity
- use `question.id` for key mapping