### PR TITLE
fix: calculation of total awarded in AlgoStats card

### DIFF
--- a/src/xgov-dapp/src/shared/stats.ts
+++ b/src/xgov-dapp/src/shared/stats.ts
@@ -23,11 +23,10 @@ export function calculateTotalAskedAndAwarded(
 
   //Filtering out a specific misconfigured mock proposal
   const filteredQuestions = votingRoundMetadata?.questions.filter((question) => !question.prompt.toLowerCase().includes('mock proposal'))
-
   filteredQuestions?.forEach((question) => {
     totalAsked += question.metadata?.ask || 0
     question.options.forEach((option) => {
-      if (question.metadata && question.metadata.threshold && optionIdsToCounts[option.id] > question.metadata.threshold) {
+      if (question.metadata && question.metadata.threshold && optionIdsToCounts[option.id] >= question.metadata.threshold) {
         totalAwarded += question.metadata?.ask || 0
       }
     })


### PR DESCRIPTION
# Overview
- in `calculateTotalAskedAndAwarded` function, include proposals which votes passed the threshold inclusive
- Jira: [AF-116](https://algorandfoundation.atlassian.net/browse/AF-116)

[AF-116]: https://algorandfoundation.atlassian.net/browse/AF-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ