### PR TITLE
feat: ENG-64 Ensures proposal cards with long and short descriptions have same height

### DIFF
--- a/src/build-a-bull/src/shared/ProposalCard.tsx
+++ b/src/build-a-bull/src/shared/ProposalCard.tsx
@@ -80,7 +80,7 @@ export const ProposalCard = ({
       </div>
       <LinearProgress color="success" style={{ height: 8, borderRadius: 10 }} className="mb-4" variant="determinate" value={percentage} />
       {description && (
-        <Collapse ref={ref} collapsedSize={`${1.5 * 4}rem`} in={expanded}>
+        <Collapse ref={ref} collapsedSize={isOverflow || hasOpened ? `${1.5 * 4}rem` : `${1.5 * 4 + 2}rem`} in={expanded}>
           <Typography dangerouslySetInnerHTML={{ __html: description }}></Typography>
         </Collapse>
       )}
@@ -89,7 +89,6 @@ export const ProposalCard = ({
           {expanded ? 'Show Less' : 'Read More'}
         </Typography>
       )}
-      <div style={isOverflow || hasOpened ? { visibility: 'hidden' } : { height: '2rem' }}></div>
     </Paper>
   )
 }

--- a/src/build-a-bull/src/shared/ProposalCard.tsx
+++ b/src/build-a-bull/src/shared/ProposalCard.tsx
@@ -46,7 +46,7 @@ export const ProposalCard = ({
   }
 
   return (
-    <Paper elevation={100000} className="p-5">
+    <Paper elevation={0} className="p-5">
       <div className="flex justify-between">
         <div>
           {hasPassed && <PassedChip />}

--- a/src/build-a-bull/src/shared/ProposalCard.tsx
+++ b/src/build-a-bull/src/shared/ProposalCard.tsx
@@ -46,7 +46,7 @@ export const ProposalCard = ({
   }
 
   return (
-    <Paper elevation={0} className="p-5">
+    <Paper elevation={100000} className="p-5">
       <div className="flex justify-between">
         <div>
           {hasPassed && <PassedChip />}
@@ -89,6 +89,7 @@ export const ProposalCard = ({
           {expanded ? 'Show Less' : 'Read More'}
         </Typography>
       )}
+      <div style={isOverflow || hasOpened ? { visibility: 'hidden' } : { height: '2rem' }}></div>
     </Paper>
   )
 }

--- a/src/xgov-dapp/src/shared/ProposalCard.tsx
+++ b/src/xgov-dapp/src/shared/ProposalCard.tsx
@@ -3,7 +3,6 @@ import LaunchIcon from '@mui/icons-material/Launch'
 import { Chip, Collapse, LinearProgress, Link, Paper, Typography } from '@mui/material'
 import { AbstainChip, CategoryChip, DidNotPassChip, MockProposalChip, PassedChip, VotesNeededToPassChip } from './Chips'
 import { useOverflow } from './hooks/useOverflow'
-import { Visibility } from '@mui/icons-material'
 
 export type ProposalCardProps = {
   link: string | undefined

--- a/src/xgov-dapp/src/shared/ProposalCard.tsx
+++ b/src/xgov-dapp/src/shared/ProposalCard.tsx
@@ -122,7 +122,7 @@ export const ProposalCard = ({
       <LinearProgress color="success" style={{ height: 8, borderRadius: 10 }} className="mb-4" variant="determinate" value={percentage} />
       {description && (
         <Collapse ref={ref} collapsedSize={isOverflow || hasOpened ? `${1.5 * 4}rem` : `${1.5 * 4 + 2}rem`} in={expanded}>
-          <Typography dangerouslySetInnerHTML={{ __html: description }}></Typography>
+          <Typography>{description}</Typography>
         </Collapse>
       )}
       {(isOverflow || hasOpened) && (

--- a/src/xgov-dapp/src/shared/ProposalCard.tsx
+++ b/src/xgov-dapp/src/shared/ProposalCard.tsx
@@ -72,7 +72,7 @@ export const ProposalCard = ({
         <LinearProgress color="error" style={{ height: 8, borderRadius: 10 }} className="mb-4" variant="determinate" value={100} />
         {description && (
           <Collapse ref={ref} collapsedSize={isOverflow || hasOpened ? `${1.5 * 4}rem` : `${1.5 * 4 + 2}rem`} in={expanded}>
-            <Typography dangerouslySetInnerHTML={{ __html: description }}></Typography>
+            <Typography>{description}</Typography>
           </Collapse>
         )}
         {(isOverflow || hasOpened) && (
@@ -122,7 +122,7 @@ export const ProposalCard = ({
       <LinearProgress color="success" style={{ height: 8, borderRadius: 10 }} className="mb-4" variant="determinate" value={percentage} />
       {description && (
         <Collapse ref={ref} collapsedSize={isOverflow || hasOpened ? `${1.5 * 4}rem` : `${1.5 * 4 + 2}rem`} in={expanded}>
-          <Typography>{description}</Typography>
+          <Typography dangerouslySetInnerHTML={{ __html: description }}></Typography>
         </Collapse>
       )}
       {(isOverflow || hasOpened) && (

--- a/src/xgov-dapp/src/shared/ProposalCard.tsx
+++ b/src/xgov-dapp/src/shared/ProposalCard.tsx
@@ -3,6 +3,7 @@ import LaunchIcon from '@mui/icons-material/Launch'
 import { Chip, Collapse, LinearProgress, Link, Paper, Typography } from '@mui/material'
 import { AbstainChip, CategoryChip, DidNotPassChip, MockProposalChip, PassedChip, VotesNeededToPassChip } from './Chips'
 import { useOverflow } from './hooks/useOverflow'
+import { Visibility } from '@mui/icons-material'
 
 export type ProposalCardProps = {
   link: string | undefined
@@ -80,6 +81,7 @@ export const ProposalCard = ({
             {expanded ? 'Show Less' : 'Read More'}
           </Typography>
         )}
+        <div style={isOverflow || hasOpened ? { visibility: 'hidden' } : { height: '2rem' }}></div>
       </Paper>
     )
   }
@@ -130,6 +132,7 @@ export const ProposalCard = ({
           {expanded ? 'Show Less' : 'Read More'}
         </Typography>
       )}
+      <div style={isOverflow || hasOpened ? { visibility: 'hidden' } : { height: '2rem' }}></div>
     </Paper>
   )
 }

--- a/src/xgov-dapp/src/shared/ProposalCard.tsx
+++ b/src/xgov-dapp/src/shared/ProposalCard.tsx
@@ -71,8 +71,8 @@ export const ProposalCard = ({
         </div>
         <LinearProgress color="error" style={{ height: 8, borderRadius: 10 }} className="mb-4" variant="determinate" value={100} />
         {description && (
-          <Collapse ref={ref} collapsedSize={`${1.5 * 4}rem`} in={expanded}>
-            <Typography>{description}</Typography>
+          <Collapse ref={ref} collapsedSize={isOverflow || hasOpened ? `${1.5 * 4}rem` : `${1.5 * 4 + 2}rem`} in={expanded}>
+            <Typography dangerouslySetInnerHTML={{ __html: description }}></Typography>
           </Collapse>
         )}
         {(isOverflow || hasOpened) && (
@@ -80,7 +80,6 @@ export const ProposalCard = ({
             {expanded ? 'Show Less' : 'Read More'}
           </Typography>
         )}
-        <div style={isOverflow || hasOpened ? { visibility: 'hidden' } : { height: '2rem' }}></div>
       </Paper>
     )
   }
@@ -122,7 +121,7 @@ export const ProposalCard = ({
       </div>
       <LinearProgress color="success" style={{ height: 8, borderRadius: 10 }} className="mb-4" variant="determinate" value={percentage} />
       {description && (
-        <Collapse ref={ref} collapsedSize={`${1.5 * 4}rem`} in={expanded}>
+        <Collapse ref={ref} collapsedSize={isOverflow || hasOpened ? `${1.5 * 4}rem` : `${1.5 * 4 + 2}rem`} in={expanded}>
           <Typography dangerouslySetInnerHTML={{ __html: description }}></Typography>
         </Collapse>
       )}
@@ -131,7 +130,6 @@ export const ProposalCard = ({
           {expanded ? 'Show Less' : 'Read More'}
         </Typography>
       )}
-      <div style={isOverflow || hasOpened ? { visibility: 'hidden' } : { height: '2rem' }}></div>
     </Paper>
   )
 }


### PR DESCRIPTION
https://algorandfoundation.atlassian.net/browse/ENG-64
Adds a placeholder div of equal size to the READ MORE button. This ensures the proposal cards are always aligned.

<img width="1175" alt="Screenshot 2023-11-29 at 11 36 18" src="https://github.com/algorandfoundation/nft_voting_tool/assets/83883690/1f7ea4ba-3f92-463c-9d62-434571b5a05e">

<img width="1241" alt="Screenshot 2023-11-29 at 11 35 09" src="https://github.com/algorandfoundation/nft_voting_tool/assets/83883690/7a4a4ad9-5d8f-4290-a105-67a375ece24f">
