### PR TITLE
fix: increase memorySize for lambda

### DIFF
--- a/infrastructure/lib/api-stack.ts
+++ b/infrastructure/lib/api-stack.ts
@@ -52,7 +52,7 @@ export class ApiStack extends cdk.Stack {
       props.timeout = Duration.seconds(60)
     }
     if (!props.memorySize) {
-      props.memorySize = 256
+      props.memorySize = 512
     }
 
     /*****************/


### PR DESCRIPTION
# Overview

- increase memorySize from `256` to `512` to decrease execution time of the api lambda

## Issues

- https://algorandfoundation.atlassian.net/browse/ENG-210