### PR TITLE
fix: ENG-206 versioning is for dapp, not xgov-dapp

### DIFF
--- a/src/dapp/package.json
+++ b/src/dapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "algorand-voting-tool",
   "private": true,
-  "version": "2.0.0",
+  "version": "2.1.0",
   "scripts": {
     "dev": "vite",
     "clean": "rimraf dist",

--- a/src/xgov-dapp/package.json
+++ b/src/xgov-dapp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "algorand-voting-tool",
   "private": true,
-  "version": "2.1.0",
+  "version": "0.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Corrects https://github.com/algorandfoundation/nft_voting_tool/pull/148 which changed the version number in the wrong package.json file