### PR TITLE
fix: total ALGO allocated displayed on homepage

### DIFF
--- a/src/xgov-dapp/src/features/rounds/VotingRoundTile.tsx
+++ b/src/xgov-dapp/src/features/rounds/VotingRoundTile.tsx
@@ -239,7 +239,7 @@ export const VotingRoundTile = ({ globalState, votingRoundStatus }: VotingRoundT
     )
   }
 
-  const { totalAsked, totalAwarded } = calculateTotalAskedAndAwarded(votingRoundResults, votingRoundMetadata, passedReserveList)
+  const { totalAsked, totalAwarded } = calculateTotalAskedAndAwarded(votingRoundResults, votingRoundMetadataClone, passedReserveList)
 
   return (
     <Box className="bg-white rounded-lg p-5">


### PR DESCRIPTION
# Overview

- Fix `VotingRoundTile` to use `votingRoundMetadataClone` when calculating total ALGO allocated for closed sessions
- Jira: [ENG-256](https://algorandfoundation.atlassian.net/browse/ENG-256)

[ENG-256]: https://algorandfoundation.atlassian.net/browse/ENG-256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ