### PR TITLE
fix: abstain/mock prposoals were disabled

### DIFF
--- a/src/xgov-dapp/src/features/vote/index.tsx
+++ b/src/xgov-dapp/src/features/vote/index.tsx
@@ -547,8 +547,10 @@ function Vote({ sort: sortProp = 'none' }: { sort?: 'ascending' | 'descending' |
                           className="w-32 bg-white m-4 rounded-xl"
                           disabled={
                             (totalAllocatedPercentage === 100 && !voteAllocationsPercentage[question.id]) ||
-                            getVotesTally(question) >=
-                              (typeof question.metadata?.threshold !== 'undefined' ? question.metadata.threshold : 0)
+                            (typeof question.metadata?.category !== 'undefined' &&
+                              !['Abstain', 'Mock'].includes(question.metadata?.category) &&
+                              getVotesTally(question) >=
+                                (typeof question.metadata?.threshold !== 'undefined' ? question.metadata.threshold : 0))
                           }
                           InputProps={{
                             inputProps: {


### PR DESCRIPTION
# Overview
- Abstain/Mock proposals were disabled since their threshold is 0.
- Added a guard to disable voting on proposals to check if category is not `Abstain` or `Mock`
- Jira: [ENG-363](https://algorandfoundation.atlassian.net/browse/ENG-363)